### PR TITLE
Set ad_step=1 after first call of rom_userchk

### DIFF
--- a/code/rom.f
+++ b/code/rom.f
@@ -64,6 +64,7 @@ c        cts='rkck  '
          time=0
          ad_step=0
          call rom_userchk
+         ad_step=1
          do i=1,ad_nsteps
             if (cts.eq.'bdfext') then
                call bdfext_step


### PR DESCRIPTION
I under stand why we set ad_step=0 before rom_userchk, but we need to set ad_step =1 after rom_userchk.
Otherwise, carrying ad_step=0, ad_beta(1,0) and ad_alpha(1,0) are not defined and will produce incorrect results.