### PR TITLE
Call rom_userchk after field is reconstructed

### DIFF
--- a/code/time.f
+++ b/code/time.f
@@ -251,8 +251,6 @@ c-----------------------------------------------------------------------
 
       real vort(lt)
 
-      call rom_userchk
-
       if (icalld.eq.0) then
          post_time=0.
          icalld=1
@@ -330,6 +328,7 @@ c        call cubar
          endif
       endif
 
+      call rom_userchk
 
       call nekgsync
       postu_time=postu_time+dnekclock()-tttime

--- a/code/time.f
+++ b/code/time.f
@@ -298,7 +298,7 @@ c        call cubar
             call opcopy(t1,t2,t3,vx,vy,vz)
 
             if (ifrom(2)) then
-               call recont(vort,ut)
+               call recont(t,ut)
             else
                call comp_vort3(vort,work1,work2,t1,t2,t3)
             endif
@@ -306,7 +306,7 @@ c        call cubar
             istep=ad_step
 
             ifto = .true. ! turn on temp in fld file
-            call outpost(vx,vy,vz,pavg,vort,'rom')
+            call outpost(vx,vy,vz,pavg,t,'rom')
             istep=jstep
          endif
       endif


### PR DESCRIPTION
The fix is to allow, when user uses 'ONB' mode, they could simply copy the subroutine they use in the FOM for computing qoi to the rom_userchk.
This change will not affect 'ON' mode also.