### PR TITLE
use ./ if path is not defined

### DIFF
--- a/code/mpar.f
+++ b/code/mpar.f
@@ -643,6 +643,11 @@ c-----------------------------------------------------------------------
       data mor4  /'.mor'/
 
       len = ltrunc(path,132)
+
+      if(len.lt.1) then
+         call chcopy(path1(1),'./',2)
+      endif
+
       if (indx1(path1(len),'/',1).lt.1) then
          call chcopy(path1(len+1),'/',1)
       endif


### PR DESCRIPTION
Nek5000 uses relative path (after 30f06bc533d957397dbe069d4d419d66c4711bfb), therefore variable path is not defined and this update is to support this change.