### PR TITLE
Remove the single quote in setting up MOR_DIR

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ This package include tools to help apply model-order reduction (MOR) to data pro
 Set shell variables (in .bashrc for BASH users):
 
 ```
-export MOR_DIR='/path/to/NekROM'
+export MOR_DIR=/path/to/NekROM
 export PATH="$MOR_DIR/bin:$PATH"
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ This package include tools to help apply model-order reduction (MOR) to data pro
 Set shell variables (in .bashrc for BASH users):
 
 ```
-export MOR_DIR=/path/to/NekROM
+export MOR_DIR="/path/to/NekROM"
 export PATH="$MOR_DIR/bin:$PATH"
 ```
 


### PR DESCRIPTION
The single quote has confused users. They were trying to do the following:

export MOR_DIR='${HOME}/NekROM' for example, with the single quote kept. This does not work.