### PR TITLE
Lower default pn to make quickstart FOM case run faster

### DIFF
--- a/examples/cyl/SIZE
+++ b/examples/cyl/SIZE
@@ -10,8 +10,8 @@ c
 
       ! BASIC
       parameter (ldim=2)               ! domain dimension (2 or 3)
-      parameter (lx1=8)                ! GLL points per element along each direction
-      parameter (lxd=12)               ! GL  points for over-integration (dealiasing) 
+      parameter (lx1=6)                ! GLL points per element along each direction
+      parameter (lxd=9)               ! GL  points for over-integration (dealiasing) 
       parameter (lx2=lx1-2)            ! GLL points for pressure (lx1 or lx1-2)
                                      
       parameter (lelg=512)            ! max number of global elements


### PR DESCRIPTION
Provided it doesn't affect the lift or drag accuracy, this would make the quickstart cyl case execute significantly faster. 

- [ ] TODO: verify lift and drag are the same.

Tag @fischer1 